### PR TITLE
Fix podchecker errors from Term::ReadLine::Perl5

### DIFF
--- a/lib/Term/ReadLine/Perl5.pm
+++ b/lib/Term/ReadLine/Perl5.pm
@@ -33,6 +33,7 @@ and show how to use the API.
   }
 
 =cut
+
 use warnings; use strict;
 use Term::ReadLine::Perl5::readline;
 no warnings 'once';
@@ -118,6 +119,7 @@ returns the actual package that executes the commands. If this package
 is used, the value is C<Term::ReadLine::Perl5>.
 
 =cut
+
 sub ReadLine {'Term::ReadLine::Perl5'}
 
 
@@ -168,6 +170,7 @@ At present, because this code has lots of global state, we currently don't
 support more than one readline instance.
 
 =cut
+
 sub new {
     my $class = shift;
     if (require Term::ReadLine) {
@@ -278,7 +281,9 @@ B<Term::ReadLine::Perl5-E<gt>newTTY>(I<IN>, I<OUT>)
 
 takes two arguments which are input filehandle and output filehandle.
 Switches to use these filehandles.
+
 =cut
+
 sub newTTY($$$) {
   my ($self, $in, $out) = @_;
   $Term::ReadLine::Perl5::readline::term_IN   = $self->{'IN'}  = $in;
@@ -296,7 +301,9 @@ If B<$minlength> is given, set C<$readline::minlength> the minimum
 length a $line for it to go into the readline history.
 
 The previous value is returned.
+
 =cut
+
 sub MinLine($;$) {
     my $old = $minlength;
     $minlength = $_[1] if @_ == 2;
@@ -354,6 +361,7 @@ number of lines.
 I<StifleHistory> is an alias for this function.
 
 =cut
+
 ### FIXME: stifle_history is still here because it updates $attribs.
 ## Pass a reference?
 sub stifle_history($$) {
@@ -458,4 +466,5 @@ select this among other compatible GNU Readline packages.
 =back
 
 =cut
+
 1;

--- a/lib/Term/ReadLine/Perl5/Common.pm
+++ b/lib/Term/ReadLine/Perl5/Common.pm
@@ -27,6 +27,7 @@ use vars qw(@EXPORT @ISA);
 Ring the bell.
 
 Should do something with I<$var_PreferVisibleBel> here, but what?
+
 =cut
 
 sub F_Ding($) {

--- a/lib/Term/ReadLine/Perl5/Dumb.pm
+++ b/lib/Term/ReadLine/Perl5/Dumb.pm
@@ -59,6 +59,7 @@ sub readline($;$$)
 =head1 SEE ALSO
 
 L<Term::ReadLine::Perl5>
+
 =cut
 
 1;

--- a/lib/Term/ReadLine/Perl5/Keymap.pm
+++ b/lib/Term/ReadLine/Perl5/Keymap.pm
@@ -8,6 +8,7 @@ Term::ReadLine::Perl5::Keymap
 
 A non-OO package subsidiary to L<Term::ReadLine::Perl5::readline> to
 initialize keymaps.
+
 =cut
 
 =head1 SUBROUTINES
@@ -15,6 +16,7 @@ initialize keymaps.
 =head2 KeymapEmacs
 
 GNU Emacs key bindings
+
 =cut
 
 use Exporter;
@@ -237,6 +239,7 @@ sub KeymapEmacs($$$) {
 =head2 KeymapVi
 
 vi input-mode key bindings
+
 =cut
 
 sub KeymapVi($$) {
@@ -260,6 +263,7 @@ sub KeymapVi($$) {
 =head2 KeymapVicmd
 
 vi command-mode key bindings
+
 =cut
 
 sub KeymapVicmd($$) {
@@ -383,6 +387,7 @@ sub KeymapVicmd($$) {
 I<vi> positioning commands suffixed to I<vi> commands like C<d>.
 
 =cut
+
 sub KeymapVipos($$$) {
     my ($fn, $keymap, $inDOS) = @_;
 
@@ -444,6 +449,7 @@ sub KeymapVipos($$$) {
 vi search string input mode for C</> and C<?>.
 
 =cut
+
 sub KeymapVisearch($$) {
     my ($fn, $keymap) = @_;
     &$fn($keymap, 'SelfInsert', 'visearch_keymap',
@@ -463,6 +469,7 @@ sub KeymapVisearch($$) {
 =head1 SEE ALSO
 
 L<Term::ReadLine::Perl5>
+
 =cut
 
 1;

--- a/lib/Term/ReadLine/Perl5/OO.pm
+++ b/lib/Term/ReadLine/Perl5/OO.pm
@@ -85,6 +85,7 @@ returns the handle for subsequent calls to following functions.
 Argument is the name of the application.
 
 =cut
+
 sub new {
     my $class = shift;
     my %args = @_==1? %{$_[0]} : @_;

--- a/lib/Term/ReadLine/Perl5/OO/History.pm
+++ b/lib/Term/ReadLine/Perl5/OO/History.pm
@@ -244,6 +244,7 @@ I<read_history()> and I<write_history()> follow GNU Readline's C
 convention of returning 0 for success and 1 for failure.
 
 =cut
+
 sub write_history($$) {
     my ($self, $filename) = @_;
     open(my $fh, '>:encoding(utf-8)', $filename ) or return $!;

--- a/lib/Term/ReadLine/Perl5/OO/Keymap.pm
+++ b/lib/Term/ReadLine/Perl5/OO/Keymap.pm
@@ -206,6 +206,7 @@ sub rl_bind_keyseq($$$;$)
 
 Accepts an array as pairs ($keyspec, $function, [$keyspec, $function]...).
 and maps the associated bindings to the current KeyMap.
+
 =cut
 
 sub bind_keys

--- a/lib/Term/ReadLine/Perl5/TermCap.pm
+++ b/lib/Term/ReadLine/Perl5/TermCap.pm
@@ -8,6 +8,7 @@ With this, I have modifed I<Term::ReadLine::Perl5> to no longer depend
 on I<Term::Readline>.
 
 =cut
+
 package Term::ReadLine::Perl5::TermCap;
 
 # Prompt-start, prompt-end, command-line-start, command-line-end

--- a/lib/Term/ReadLine/Perl5/Tie.pm
+++ b/lib/Term/ReadLine/Perl5/Tie.pm
@@ -17,6 +17,7 @@ attributes.
 L<Term::ReadLine::Perl5>
 
 =cut
+
 package Term::ReadLine::Perl5::Tie;
 
 # version might not be below other places in this routine

--- a/lib/Term/ReadLine/Perl5/readline-guide.pod
+++ b/lib/Term/ReadLine/Perl5/readline-guide.pod
@@ -237,7 +237,7 @@ If defined when package is require'd, F<~/.inputrc> will not be read.
 
 =item C<@rl_History>
 array of previous lines input.
-n
+
 =item C<$rl_HistoryIndex>
 
 history pointer (for moving about history array)

--- a/lib/Term/ReadLine/Perl5/readline.pm
+++ b/lib/Term/ReadLine/Perl5/readline.pm
@@ -19,6 +19,7 @@ Someone please volunteer to rewrite this!
 See also L<Term::ReadLine::Perl5::readline-guide>.
 
 =cut
+
 use warnings;
 package Term::ReadLine::Perl5::readline;
 use File::Glob ':glob';
@@ -110,6 +111,7 @@ my $Vi_search_reverse;  # True for '?' search, false for '/'
 =head1 SUBROUTINES
 
 =cut
+
 # Fix: case-sensitivity of inputrc on/off keywords in
 #      `set' commands. readline lib doesn't care about case.
 # changed case of keys 'On' and 'Off' to 'on' and 'off'
@@ -688,6 +690,7 @@ sub rl_bind_keyseq($$)
 
 Accepts an array as pairs ($keyspec, $function, [$keyspec, $function]...).
 and maps the associated bindings to the current KeyMap.
+
 =cut
 
 sub rl_bind
@@ -857,6 +860,7 @@ the only useful one is directory since that will cause a further
 completion to continue.
 
 =cut
+
 sub rl_filename_list_deprecated
 {
     my $pattern = $_[0];
@@ -952,6 +956,7 @@ Parse I<$line> as if it had been read from the inputrc file and
 perform any key bindings and variable assignments found.
 
 =cut
+
 sub rl_parse_and_bind($)
 {
     my $line = shift;
@@ -972,6 +977,7 @@ to a routine that would look at the context of the word being completed
 and return the appropriate possibilities.
 
 =cut
+
 sub rl_basic_commands
 {
      @rl_basic_commands = @_;
@@ -990,6 +996,7 @@ B<rl_read_initfile>(I<$filename>)
 Read keybindings and variable assignments from filename I<$filename>.
 
 =cut
+
 sub rl_read_init_file($) {
     read_an_init_file(shift, 0);
 }
@@ -1163,6 +1170,7 @@ sub F_AcceptLine
 Move `back' through the history list, fetching the previous command.
 
 =cut
+
 sub F_PreviousHistory {
     &get_line_from_history($rl_HistoryIndex - shift);
 }
@@ -1172,6 +1180,7 @@ sub F_PreviousHistory {
 Move `forward' through the history list, fetching the next command.
 
 =cut
+
 sub F_NextHistory {
     &get_line_from_history($rl_HistoryIndex + shift);
 }
@@ -1181,6 +1190,7 @@ sub F_NextHistory {
 Move to the first line in the history.
 
 =cut
+
 sub F_BeginningOfHistory
 {
     &get_line_from_history(0);
@@ -1192,6 +1202,7 @@ Move to the end of the input history, i.e., the line currently being
 entered.
 
 =cut
+
 sub F_EndOfHistory { &get_line_from_history(@rl_History); }
 
 =head3 F_ReverseSearchHistory
@@ -1200,12 +1211,13 @@ Search backward starting at the current line and moving `up' through
 the history as necessary. This is an incremental search.
 
 =cut
+
 sub F_ReverseSearchHistory
 {
     &DoSearch($_[0] >= 0 ? 1 : 0);
 }
 
-=head3
+=head3 F_ForwardSearchHistory
 
 Search forward starting at the current line and moving `down' through
 the the history as necessary. This is an increment
@@ -1225,6 +1237,7 @@ must match at the beginning of a history line. This is a
 non-incremental search. By default, this command is unbound.
 
 =cut
+
 sub F_HistorySearchBackward
 {
     &DoSearchStart(($_[0] >= 0 ? 1 : 0),substr($line,0,$D));
@@ -1414,6 +1427,7 @@ past that word as well. If the insertion point is at the end of the
 line, this transposes the last two words on the line.
 
 =cut
+
 sub F_TransposeWords {
     my $c = shift;
     return F_Ding() unless $c;
@@ -1449,6 +1463,7 @@ Uppercase the current (or following) word. With a negative argument,
 uppercase the previous word, but do not move the cursor.
 
 =cut
+
 sub F_UpcaseWord     { &changecase($_[0], 'up');   }
 
 =head3 F_DownCaseWord
@@ -1457,6 +1472,7 @@ Lowercase the current (or following) word. With a negative argument,
 lowercase the previous word, but do not move the cursor.
 
 =cut
+
 sub F_DownCaseWord   { &changecase($_[0], 'down'); }
 
 =head3 F_CapitalizeWord
@@ -1465,6 +1481,7 @@ Capitalize the current (or following) word. With a negative argument,
 capitalize the previous word, but do not move the cursor.
 
 =cut
+
 sub F_CapitalizeWord { &changecase($_[0], 'cap');  }
 
 =head3 F_OverwriteMode
@@ -1481,6 +1498,7 @@ character before point with a space.
 By default, this command is unbound.
 
 =cut
+
 sub F_OverwriteMode
 {
     $InsertMode = 0;
@@ -1551,6 +1569,7 @@ currently not on a word (or just at the start of a word), to the start
 of the previous word.
 
 =cut
+
 sub F_BackwardKillWord
 {
     my $count = shift;
@@ -1581,6 +1600,7 @@ Kill the text in the current region. By default, this command is
 unbound.
 
 =cut
+
 sub F_KillRegion {
     return F_Ding() unless $line_rl_mark == $rl_HistoryIndex;
     $rl_mark = length $line if $rl_mark > length $line;
@@ -1593,6 +1613,7 @@ sub F_KillRegion {
 Copy the text in the region to the kill buffer, so it can be yanked right away. By default, this command is unbound.
 
 =cut
+
 sub F_CopyRegionAsKill {
     return F_Ding() unless $line_rl_mark == $rl_HistoryIndex;
     $rl_mark = length $line if $rl_mark > length $line;
@@ -1608,6 +1629,7 @@ sub F_CopyRegionAsKill {
 Yank the top of the kill ring into the buffer at point.
 
 =cut
+
 sub F_Yank
 {
     remove_selection();
@@ -1633,6 +1655,7 @@ Add this digit to the argument already accumulating, or start a new
 argument. C<M--> starts a negative argument.
 
 =cut
+
 sub F_DigitArgument
 {
     my $in = chr $_[1];
@@ -1688,6 +1711,7 @@ argument count sixteen, and so on. By default, this is not bound to a
 key.
 
 =cut
+
 sub F_UniversalArgument
 {
     &F_DigitArgument;
@@ -1781,6 +1805,7 @@ Abort the current editing command and ring the terminal's bell
 (subject to the setting of bell-style).
 
 =cut
+
 sub F_Abort
 {
     F_Ding();
@@ -1825,6 +1850,7 @@ sub F_RevertLine
 Perform tilde expansion on the current word.
 
 =cut
+
 sub F_TildeExpand {
 
     my $what_to_do = shift;
@@ -2013,6 +2039,7 @@ sub F_EmacsEditingMode
 =head3 F_Interrupt
 
 (Attempt to) interrupt the current program via I<kill('INT')>
+
 =cut
 
 sub F_Interrupt
@@ -2047,7 +2074,7 @@ sub F_ToggleInsertMode
     $InsertMode = !$InsertMode;
 }
 
-=head3
+=head3 F_Suspend
 
 (Attempt to) suspend the program via I<kill('TSTP')>
 
@@ -2073,7 +2100,9 @@ sub F_Suspend
 Ring the bell.
 
 Should do something with I<$var_PreferVisibleBel> here, but what?
+
 =cut
+
 sub F_Ding {
     Term::ReadLine::Perl5::Common::F_Ding($term_OUT)
 }
@@ -2095,6 +2124,7 @@ Repeat the most recent one of these vi commands:
    a A c C d D i I p P r R s S x X ~
 
 =cut
+
 sub F_ViRepeatLastCommand {
     my($count) = @_;
     return F_Ding() if !$Last_vi_command;
@@ -2258,6 +2288,7 @@ Prepend line with '#', add to history, and clear the input buffer
 (this feature was borrowed from ksh).
 
 =cut
+
 sub F_SaveLine
 {
     local $\ = '';
@@ -2274,7 +2305,9 @@ sub F_SaveLine
 
 Come here if we see a non-positioning keystroke when a positioning
 keystroke is expected.
+
 =cut
+
 sub F_ViNonPosition {
     # Not a positioning command - undefine the cursor to indicate the error
     #     to get_position().
@@ -2285,6 +2318,7 @@ sub F_ViNonPosition {
 
 Comes here if we see I<esc>I<char>, but I<not> an arrow key or other
 mapped sequence, when a positioning keystroke is expected.
+
 =cut
 
 sub F_ViPositionEsc {
@@ -2344,7 +2378,9 @@ sub F_ViBackwardDeleteChar {
 =head3 F_ViFirstWord
 
 Go to first non-space character of line.
+
 =cut
+
 sub F_ViFirstWord
 {
     $D = 0;
@@ -2356,6 +2392,7 @@ sub F_ViFirstWord
 # Like the emacs case transforms.
 
 I<Note>: this doesn't work for multi-byte characters.
+
 =cut
 
 sub F_ViToggleCase {
@@ -2390,7 +2427,9 @@ Search history for matching string.  As with vi in nomagic mode, the
 ^, $, \<, and \> positional assertions, the \* quantifier, the \.
 character class, and the \[ character class delimiter all have special
 meaning here.
+
 =cut
+
 sub F_ViSearch {
     my($n, $ord) = @_;
 
@@ -2471,7 +2510,9 @@ sub F_ViSearchBackwardDeleteChar {
 =head3 F_ViChangeEntireLine
 
 Kill entire line and enter input mode
+
 =cut
+
 sub F_ViChangeEntireLine
 {
     &start_dot_buf(@_);
@@ -2482,7 +2523,9 @@ sub F_ViChangeEntireLine
 =head3 F_ViChangeChar
 
 Kill characters and enter input mode
+
 =cut
+
 sub F_ViChangeChar
 {
     &start_dot_buf(@_);
@@ -3473,6 +3516,7 @@ B<redisplay>[(I<$prompt>)]
 If an argument I<$prompt> is given, it is used instead of the prompt.
 Updates the screen to reflect the current value of global C<$line> via
 L<rl_redisplay>.
+
 =cut
 
 sub redisplay(;$)
@@ -3638,6 +3682,7 @@ pointing to a 1-byte char.
 TODO: handle Unicode
 
 =cut
+
 sub CharSize
 {
     my $index = shift;
@@ -3796,6 +3841,7 @@ If I<$up_down_caps> is 'up' to upcase I<$count> words;
 If I<$count> is negative, the dot is not moved.
 
 =cut
+
 sub changecase
 {
     my $op = $_[1];
@@ -3941,6 +3987,7 @@ This is intended to be the called first in a potentially repetitive
 search, which is why the unusual return value. See also L<search>.
 
 =cut
+
 sub searchStart($$$) {
   my ($i, $reverse, $str) = @_;
   $i += $reverse ? - 1: +1;
@@ -4007,6 +4054,7 @@ Returns true if a completion was done, false otherwise, so vi completion
     routines can test it.
 
 =cut
+
 sub complete_internal
 
 {
@@ -4112,6 +4160,7 @@ prefix prepended as the first item of the list.  Therefore, the list
 will either be of zero length (meaning no matches) or of 2 or more.....
 
 =cut
+
 sub completion_matches
 {
     my ($func, $text, $line, $start) = @_;
@@ -4257,6 +4306,7 @@ sub do_delete {
     get_position($count, $ord, $fulline_ord, $poshash)
 
 Interpret vi positioning commands
+
 =cut
 
 sub get_position {
@@ -4447,4 +4497,5 @@ sub read_an_init_file($;$)
 L<Term::ReadLine::Perl5>
 
 =cut
+
 1;


### PR DESCRIPTION
I noticed a number of POD errors in Term::ReadLine::Perl5.  Tracked and corrected with podchecker and the results in this pull request.