### PR TITLE
Fix t/10test-readline.t: missing "new"

### DIFF
--- a/t/10test-readline.t
+++ b/t/10test-readline.t
@@ -29,7 +29,7 @@ my $verbose = @ARGV && ($ARGV[0] eq 'verbose');
 # test new method
 
 my $t;
-eval { $t  = Term::ReadLine::Perl5->('ReadLineTest'); };
+eval { $t  = Term::ReadLine::Perl5->new('ReadLineTest'); };
 plan skip_all => "Need access to tty" unless $t;
 ok($t, "new method, new's");
 


### PR DESCRIPTION
This test was silently being skipped due to a failure at the statement

```
eval { $t  = Term::ReadLine::Perl5->('ReadLineTest'); };
```

which was being interpreted as

```
eval { $t  = Term::ReadLine::Perl5()->('ReadLineTest'); };
```

emitting a complaint about a missing `Term::ReadLine::Perl5()` function.
