### PR TITLE
Fix build with cpanp and prefer_makefile_pl

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -20,7 +20,6 @@ my $builder = Module::Build->new(
     module_name         => 'Term::ReadLine::Perl5',
     add_to_cleanup      => ['Term-ReadLine-Perl5*', 'tmp*', '.history.text',
 			    'pod2htm*.tmp'],
-    create_makefile_pl  => 'passthrough',
     dist_abstract       => 'Perl5 version of GNU ReadLine.',
     dist_author         => 'Rocky Bernstein <rocky@cpan.org>',
     dist_version_from   => 'lib/Term/ReadLine/Perl5.pm',

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,12 +1,10 @@
 Build.PL
 ChangeLog
 Changes
-GNUmakefile
 LICENSE
 MANIFEST
 META.json
 META.yml
-Makefile.PL
 README.pod			     # General overview
 lib/Term/ReadLine/Perl5.pm
 lib/Term/ReadLine/Perl5/CHANGES	     # What's up?

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -76,6 +76,8 @@ git2cl$
 ^Common\.pm$
 ^Tk\.pm$
 
+# Avoid including a file that confuses cpanp in some configs
+^GNUmakefile$
 
 # Avoid archives of this distribution
 \bDevel-Trepan-[\d\.\_]+


### PR DESCRIPTION
See https://github.com/rocky/p5-Term-ReadLine-Perl5/issues/18 .

For the diagnosis:

```
<rindolf> Hi all! Is this a cpanp problem? https://github.com/rocky/p5-Term-ReadLine-Perl5/issues/18
<mst> hmm, entirely possible
<BinGOs> curiously it runs Build.PL then does make instead of running Build
<BinGOs> and because there is a GNUMakefile that gets run and that makefile has things like 'perl Build' so that perl is the one in the PATH not what ran Build.PL initially.
<BinGOs> I wonder if there is a corner-case here with detection of GNUMakefile
<mst> ooooo
<haarg> Makefile.PL is running Build.PL
<BinGOs> yeah, fuck that shit.
<mst> create_makefile_pl => 'passthrough' # AUGH
<mst> basically, that needs killing with fire and the GNUMakefile needs to go into MANIFEST.SKIP
<rindolf> thanks, all
<BinGOs> short story is: set prefer_makefile 0 in your CPANPLUS config
<rindolf> BinGOs: ah
<BinGOs> if there is both a Build.PL and a Makefile.PL that will prefer Build.PL
<rindolf> BinGOs: yeah
* kid51 has quit (Quit: Leaving.)
<mst> rindolf: but, yeah, if you could tell the dist author to stop doing that as well that'd be great
<rindolf> mst: i'll send a pull req
```

(quoted with permission.)