### PR TITLE
File Path Expansion

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Release history for Perl module Term::ReadLine::Perl5
 {{ NEXT }}
 
 - Make `/path/to/dir[TAB]` *NOT* append trailing space
+- Make `/path/to/dir/[TAB]` *ONLY* show "basename" of matches
 
 1.45 2017-10-18
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Release history for Perl module Term::ReadLine::Perl5
 
+{{ NEXT }}
+
+- Make `/path/to/dir[TAB]` *NOT* append trailing space
+
 1.45 2017-10-18
 
 - Fixes from Adriano Ferreira

--- a/lib/Term/ReadLine/Perl5/readline.pm
+++ b/lib/Term/ReadLine/Perl5/readline.pm
@@ -825,6 +825,10 @@ GNU Readline also will complete partial I<~> names; for example
 I<~roo> maybe expanded to C</root> for the root user. When
 getpwent/setpwent is available we provide that.
 
+Also, like I<Term::ReadLine::GNU>, if there are multiple potential
+matches, only the trailing path element (i.e., C<basename(3)>) will be
+displayed.
+
 The user of this package can set I<$rl_completion_function> to
 'rl_filename_list' to restore the default of filename matching if
 they'd changed it earlier, either directly or via &rl_basic_commands.
@@ -4107,6 +4111,9 @@ sub complete_internal
         }
     } elsif ($what_to_do eq '?') {
         shift(@matches); ## remove prepended common prefix
+
+        ### Strip off any "path/prefix/" when we pretty print our match list.
+        @matches = map { /.*\/(.+)$/ ? $1 : $_ } @matches;
         local $\ = '';
         print $term_OUT "\n\r";
         # print "@matches\n\r";

--- a/lib/Term/ReadLine/Perl5/readline.pm
+++ b/lib/Term/ReadLine/Perl5/readline.pm
@@ -817,9 +817,9 @@ This function corresponds to the L<Term::ReadLine::GNU> function
 I<rl_filename_list)>. But that doesn't handle tilde expansion while
 this does. Also, directories returned will have the '/' suffix
 appended as is the case returned by GNU Readline, but not
-I<Term::ReadLine::GNU>. Adding the '/' suffix is useful in completion
-because it forces the next completion to complete inside that
-directory.
+I<Term::ReadLine::GNU>. Adding the '/' suffix (and B<NOT> the
+trailing space) is useful in completion because it forces the next
+completion to complete inside that directory.
 
 GNU Readline also will complete partial I<~> names; for example
 I<~roo> maybe expanded to C</root> for the root user. When
@@ -4089,8 +4089,12 @@ sub complete_internal
         return &F_Ding;
     } elsif ($what_to_do eq "\t") {
         my $replacement = shift(@matches);
+
+	### Note: We don't want to append a space after tab-expanding a directory;
+	### we'd rather be able to continue completion farther down the hierarchy.
 	$replacement .= $rl_completer_terminator_character
-	    if @matches == 1 && !$rl_completion_suppress_append;
+	    if @matches == 1 && !$rl_completion_suppress_append
+	       && !( $rl_completion_function eq 'rl_filename_list' && $replacement =~ m,/$, );
         &F_Ding if @matches != 1;
         if ($var_TcshCompleteMode) {
             @tcsh_complete_selections = (@matches, $text);


### PR DESCRIPTION
This PR actually fixes two issues I've been having.  (I can split them into separate PRs if you'd prefer, or squash them into a single commit, but the whole thing is literally only three lines of code...  «grin»)

### Suppress File List Completion Terminator/Separator
```
PERL_RL="Perl5" perl -MTerm::ReadLine -E 'Term::ReadLine->new->readline("Path? ")'
Path? /usr[TAB]
```
Would print:
```
Path? /usr/ [SPACE]
```
And subsequent `TAB`s would show the files in the *CURRENT* directory...  :-\
____
### Show Only `basename()` of File List Matches
```
PERL_RL="Perl5" perl -MTerm::ReadLine -E 'Term::ReadLine->new->readline("Path? ")'
Path? /usr/bin/[TAB]
```
Would print:
```
/usr/bin/a2p       /usr/bin/java       /usr/bin/rmiregistry
/usr/bin/abs2rel   /usr/bin/javac      /usr/bin/rpcgen
/usr/bin/ack       /usr/bin/javadoc    /usr/bin/rpm
...
```
Now it strips everything up to the last, non-terminal `/`, like e.g., `bash(1)`:
``` 
a2p              dsimport         keytool          phar             ssh-agent
abs2rel          dsmemberutil     kgetcred         phar.phar        ssh-copy-id
ack              dsymutil         kill.d           php              ssh-keygen
actool           dtruss           killall          php-config       ssh-keyscan
...
```
____
Cheers!  :beers: