### PR TITLE
Fix `local $_` leakage

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Release history for Perl module Term::ReadLine::Perl5
   (Application code can then handle it in an `eval {}` block, etc.)
 - Make `/path/to/dir[TAB]` *NOT* append trailing space
 - Make `/path/to/dir/[TAB]` *ONLY* show "basename" of matches
+- Fix `local $_` leakage ("Spooky Action At A Distance")
 
 1.45 2017-10-18
 

--- a/lib/Term/ReadLine/Perl5/readline.pm
+++ b/lib/Term/ReadLine/Perl5/readline.pm
@@ -889,7 +889,7 @@ sub rl_filename_list_deprecated
 # local-bound arrays I<@action> and I<@level>.
 sub parse_and_bind($$$)
 {
-    $_ = shift;
+    local $_ = shift;
     my $file = shift;
     my $include_depth = shift;
     s/^\s+//;


### PR DESCRIPTION
I'm not sure what exact conditions triggered it (perl v5.20.0 ?),
but this was causing "Spooky Action At A Distance" -- i.e., `$_`
was being modified *WAAAAY* up in the caller's caller's caller's
scope.